### PR TITLE
Shutdown agents just in case

### DIFF
--- a/src/clj_check/check.clj
+++ b/src/clj_check/check.clj
@@ -25,6 +25,7 @@
                     (sequence
                      (comp (map check-ns) (remove nil?))
                      namespaces))]
+    (shutdown-agents)
     (when-not (zero? failures)
       (System/exit failures))))
 


### PR DESCRIPTION
If loaded code inadvertently uses the agent threadpool, clj-check will hang. This will forcibly shutdown the backing threadpools so we can cleanly and quickly exit.